### PR TITLE
wrap img in anchor tag to add navigation to home page

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -12,7 +12,7 @@ const activePageStyling = (path: string) => path == currentPath ? "text-secondar
 
 <nav class="sticky top-0 bg-base-100 z-40 w-full">
     <div class="max-w-screen-xl h-24 flex flex-wrap items-center justify-between mx-auto p-4">
-        <img src="/imgs/yk-banner1.png" class="h-12" alt="Yaksha Banner" />
+        <a href="/"><img src="/imgs/yk-banner1.png" class="h-12" alt="Yaksha Banner" /></a>
 
         <!-- For small devices use consise burger menu, basically just phones -->
         <details class="dropdown dropdown-end md:hidden">


### PR DESCRIPTION
It is generally expected that clicking a website's logo will navigate the user back to the home page.